### PR TITLE
The module only accepts uppercase hex letters

### DIFF
--- a/concordsvr/concord/concord.py
+++ b/concordsvr/concord/concord.py
@@ -219,7 +219,7 @@ def update_message_checksum(bin_msg):
 def encode_message_to_ascii(bin_msg):
     s = ''
     for b in bin_msg:
-        s += '%02x' % b
+        s += '%02X' % b
     return s
 
 def decode_message_from_ascii(ascii_msg):


### PR DESCRIPTION
Page 5 of the Protocol document:

"Data
An 8-bit binary value is sent as two upper-case ASCII digits (‘0’...’9’, ‘A’...’F’)."

This fix changes the python format to match the specification.

I discovered this change was necessary when checksums involved hex digits.  The messages were ignored when sent using lower case ascii, and recognized with the change.
